### PR TITLE
Avoid dashboard crash on macOS when SMC data is unavailable.

### DIFF
--- a/miner/dashboard.js
+++ b/miner/dashboard.js
@@ -785,43 +785,46 @@ class CLIDashboard{
 
 				let parts = smcData.split('**** SMC sensors ****')[1];
 				let isSMCDone = false
-				parts.split('\n').map(line=>{
-					if(line.indexOf('****') >= 0 || isSMCDone){
-						//section is done
-						isSMCDone = true;
-						return false;
-					}
-					if(line.indexOf('GPU') == 0){
-						if(line.indexOf('temperature') >= 0){
-							//is temp
+				if (parts !== undefined) {
+					parts.split('\n').map(line=>{
+						if(line.indexOf('****') >= 0 || isSMCDone){
+							//section is done
+							isSMCDone = true;
+							return false;
+						}
+						if(line.indexOf('GPU') == 0){
+							if(line.indexOf('temperature') >= 0){
+								//is temp
+								if(typeof this.gpus != "undefined"){
+									Object.keys(this.gpus).map(key=>{
+										let gpuD = this.gpus[key];
+										let tempD = {temperature:parseFloat(line.split(':')[1].replace('C','').trim()),time:moment().format('HH:mm')};
+	
+										/*console.log('');
+										console.log('tempD',tempD)*/
+										this.gpus[key].data.temperature.push(tempD);
+									})
+								}
+							}
+							
+						}
+						if(line.indexOf('Fan') >= 0){
+							//its the fan speed
+							let fanSpeed = line.split(':')[1].replace('rpm','').trim();
 							if(typeof this.gpus != "undefined"){
 								Object.keys(this.gpus).map(key=>{
 									let gpuD = this.gpus[key];
-									let tempD = {temperature:parseFloat(line.split(':')[1].replace('C','').trim()),time:moment().format('HH:mm')};
-
+									let fanD = {fans:Math.floor(parseFloat(fanSpeed)/6200*100),time:moment().format('HH:mm')};
+									//console.log('fan data isset',fanD);
 									/*console.log('');
 									console.log('tempD',tempD)*/
-									this.gpus[key].data.temperature.push(tempD);
+									this.gpus[key].data.fan.push(fanD);
 								})
 							}
 						}
-						
-					}
-					if(line.indexOf('Fan') >= 0){
-						//its the fan speed
-						let fanSpeed = line.split(':')[1].replace('rpm','').trim();
-						if(typeof this.gpus != "undefined"){
-							Object.keys(this.gpus).map(key=>{
-								let gpuD = this.gpus[key];
-								let fanD = {fans:Math.floor(parseFloat(fanSpeed)/6200*100),time:moment().format('HH:mm')};
-								//console.log('fan data isset',fanD);
-								/*console.log('');
-								console.log('tempD',tempD)*/
-								this.gpus[key].data.fan.push(fanD);
-							})
-						}
-					}
-				});
+					});
+				}
+
 				let powerParts = smcData.split('**** Processor usage ****')[1].split('\n');
 				let hasFoundPowerPart = 0;
 				let powerW = 0;


### PR DESCRIPTION
Hi folks,

I tried playing around with mining on a Mac mini, and the barebones command line script `mine.js` worked flawlessly, but the dashboard script would consistently crash for me because SMC data is unavailable on my machine for whatever reason, even when running the script with `sudo`. For good measure, I also tried explicitly running e.g.

```
sudo powermetrics -i 200 -n1 --samplers smc
```

directly from the command line to validate, and likewise, the SMC info is missing:

```
unable to get smc values
Machine model: Macmini8,1
SMC version: Unknown
EFI version: 1037.340.0
OS version: 19E234g
Boot arguments: chunklist-security-epoch=0 -chunklist-no-rev2-dev
Boot time: Sat Feb 22 10:29:56 2020
```

(Running a beta of `10.15.4` FWIW, but seemingly this issue has plagued other Mac mini owners on earlier OS releases too, [see last comment on this StackExchange post](https://apple.stackexchange.com/a/359529)).

As a janky workaround (so I can at least get some of the joy out of the dashboard, despite not having access to temp/fan info), I wrapped the SMC data extraction bit in a simple `undefined` conditional check. Now the script works on my Mac, and I can run the dashboard!

Bummer that the SMC info seems to be inconsistently available across various Apple hardware and OS releases :(, hope this helps other folks.

So delighted that this works at all on macOS though! Seems relatively uncommon in the mining world, enthusiasts be damned.

![Screenshot 2020-02-22 at 11 24 59](https://user-images.githubusercontent.com/193187/75085645-3f955d80-5566-11ea-910a-54780a244f3f.png)

Thanks and feel free to view this as a strawman PR, just raising for visibility with a "duct tape" fix that worked for me.