### PR TITLE
Update HandyMiner.js

### DIFF
--- a/miner/HandyMiner.js
+++ b/miner/HandyMiner.js
@@ -220,7 +220,7 @@ class HandyMiner {
     }
     if(!fs.existsSync(process.env.HOME+'/.HandyMiner/version.txt')){
       let myMin = Math.floor(Math.random()*59.999);
-      fs.writeFileSync(process.env.HOME+'/.HandyMiner/version.txt',myMin);
+      fs.writeFileSync(process.env.HOME+'/.HandyMiner/version.txt',myMin.toString());
     }
     let gpus = this.gpuListString.split(',').map(s=>{return s.trim();});
     let platform = this.platformID;


### PR DESCRIPTION
Fix for `TypeError [ERR_INVALID_ARG_TYPE] at Object.writeFileSync` on the latest Node version.